### PR TITLE
Fix fatal error which occurs due to calling matcher() on

### DIFF
--- a/src/libphonenumber/PhoneNumberUtil.php
+++ b/src/libphonenumber/PhoneNumberUtil.php
@@ -1712,9 +1712,8 @@ class PhoneNumberUtil
                     0,
                     $numberLength
                 );
-                if ($isViableOriginalNumber &&
-                    !$nationalNumberRule->matcher($transformedNumber->toString())->matches()
-                ) {
+                $transformedNumberRuleMatcher = new Matcher($nationalNumberRule, $transformedNumber);
+                if ($isViableOriginalNumber && !$transformedNumberRuleMatcher->matches()) {
                     return false;
                 }
                 if ($carrierCode !== null && $numOfGroups > 1) {


### PR DESCRIPTION
$nationalNumberRule, which doesn't have a matcher() method attached to
it.

Create a new Matcher with the $nationalNumberRule and the
$transformedNumber to replace the broken condition.

Receive fatal error when the following code is executed:

```
<?php
require_once __DIR__ . '/../vendor/autoload.php';
use libphonenumber\PhoneNumberFormat;                                                                                                                                                                                                   
use libphonenumber\PhoneNumberUtil;

$phoneNumberUtil = PhoneNumberUtil::getInstance();
$number = $phoneNumberUtil->parse('011543549480042', 'US');
```

This parses correctly in the libphonenumber demo at http://libphonenumber.appspot.com/

This commit fixes the fatal error and works correctly.
