### PR TITLE
Correct typo in getting Carrier name example

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ $swissNumberProto = $phoneUtil->parse("798765432", "CH");
 
 $carrierMapper = \libphonenumber\PhoneNumberToCarrierMapper::getInstance();
 // Outputs "Swisscom"
-echo $carrierMapper->getDescriptionForNumber($swissNumberProto, "en");
+echo $carrierMapper->getNameForNumber($swissNumberProto, "en");
 ```
 
 ### Mapping Phone Numbers to TimeZones


### PR DESCRIPTION
The method for retrieving the name of the carrier
for the given phone number is named `getNameForNumber`
  and not `getDescriptionForNumber`

See
[PhoneNumberToCarrierMapper.php](https://github.com/sergeylukin/libphonenumber-for-php/blob/master/src/libphonenumber/PhoneNumberToCarrierMapper.php)
for reference
