### PR TITLE
Update build.xml to use svn

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2,7 +2,6 @@
 <project name="libphonenumber-for-php" default="test">
 
     <property name="build.script" value="build/build.php"/>
-    <property name="resources.url" value="https://libphonenumber.googlecode.com/svn/trunk/resources/"/>
 
     <property name="svn.url" value="http://libphonenumber.googlecode.com/svn/trunk/"/>
     <property name="svn.path" value="libphonenumber-data-dir"/>
@@ -77,17 +76,17 @@
     </target>
 
     <target name="svn-checkout">
-        <exec executable="svn" passthru="true">
+        <exec executable="svn" passthru="true" checkreturn="true">
             <arg value="checkout"/>
             <arg value="${svn.url}"/>
             <arg value="${svn.path}"/>
         </exec>
     </target>
 
-    <target name="build-test-metadata" description="Build test Phone Metadata">
+    <target name="build-test-metadata" description="Build test Phone Metadata" depends="svn-checkout">
         <exec executable="${build.script}" passthru="true">
             <arg value="BuildMetadataPHPFromXML"/>
-            <arg value="${resources.url}PhoneNumberMetadataForTesting.xml"/>
+            <arg value="${svn.path}/resources/PhoneNumberMetadataForTesting.xml"/>
             <arg value="${data.testCoreData}"/>
             <arg value="PhoneNumberMetadataForTesting"/>
             <arg value="CountryCodeToRegionCodeMapForTesting"/>
@@ -113,10 +112,10 @@
     </target>
 
 
-    <target name="build-phone-metadata">
+    <target name="build-phone-metadata" depends="svn-checkout">
         <exec executable="${build.script}" passthru="true">
             <arg value="BuildMetadataPHPFromXML"/>
-            <arg value="${resources.url}PhoneNumberMetadata.xml"/>
+            <arg value="${svn.path}/resources/PhoneNumberMetadata.xml"/>
             <arg value="${data.coreData}"/>
             <arg value="PhoneNumberMetadata"/>
             <arg value="CountryCodeToRegionCodeMap"/>
@@ -125,10 +124,10 @@
         </exec>
     </target>
 
-    <target name="build-short-metadata">
+    <target name="build-short-metadata" depends="svn-checkout">
         <exec executable="${build.script}" passthru="true">
             <arg value="BuildMetadataPHPFromXML"/>
-            <arg value="${resources.url}ShortNumberMetadata.xml"/>
+            <arg value="${svn.path}/resources/ShortNumberMetadata.xml"/>
             <arg value="${data.coreData}"/>
             <arg value="ShortNumberMetadata"/>
             <arg value="ShortNumbersRegionCodeSet"/>
@@ -137,10 +136,10 @@
         </exec>
     </target>
 
-    <target name="build-alternate-metadata">
+    <target name="build-alternate-metadata" depends="svn-checkout">
         <exec executable="${build.script}" passthru="true">
             <arg value="BuildMetadataPHPFromXML"/>
-            <arg value="${resources.url}PhoneNumberAlternateFormats.xml"/>
+            <arg value="${svn.path}/resources/PhoneNumberAlternateFormats.xml"/>
             <arg value="${data.coreData}"/>
             <arg value="PhoneNumberAlternateFormats"/>
             <arg value="AlternateFormatsCountryCodeSet"/>
@@ -149,7 +148,7 @@
         </exec>
     </target>
 
-    <target name="build-carrier-data">
+    <target name="build-carrier-data" depends="svn-checkout">
         <exec executable="${build.script}" passthru="true">
             <arg value="GeneratePhonePrefixData"/>
             <arg value="${svn.path}/resources/carrier/"/>
@@ -157,7 +156,7 @@
         </exec>
     </target>
 
-    <target name="build-geo-data">
+    <target name="build-geo-data" depends="svn-checkout">
         <exec executable="${build.script}" passthru="true">
             <arg value="GeneratePhonePrefixData"/>
             <arg value="${svn.path}/resources/geocoding/"/>
@@ -165,7 +164,7 @@
         </exec>
     </target>
 
-    <target name="build-timezones-data">
+    <target name="build-timezones-data" depends="svn-checkout">
         <exec executable="${build.script}" passthru="true">
             <arg value="GenerateTimeZonesMapData"/>
             <arg value="${svn.path}/resources/timezones/map_data.txt"/>
@@ -173,7 +172,7 @@
         </exec>
     </target>
 
-    <target name="build-timezones-test-data">
+    <target name="build-timezones-test-data" depends="svn-checkout">
         <exec executable="${build.script}" passthru="true">
             <arg value="GenerateTimeZonesMapData"/>
             <arg value="${svn.path}/resources/test/timezones/map_data.txt"/>


### PR DESCRIPTION
Updated build.xml to avoid remote calls when svn repo can be used and to throw a error if svn is not installed.
