### PR TITLE
Avoid `Segmentation fault` with PHP 5.5.14

### DIFF
--- a/src/libphonenumber/geocoding/PhoneNumberOfflineGeocoder.php
+++ b/src/libphonenumber/geocoding/PhoneNumberOfflineGeocoder.php
@@ -120,12 +120,14 @@ class PhoneNumberOfflineGeocoder
      */
     private function getRegionDisplayName($regionCode, $locale)
     {
-        $loc = Locale::getDisplayRegion(
+        if ($regionCode === null || $regionCode == 'ZZ' || $regionCode === PhoneNumberUtil::REGION_CODE_FOR_NON_GEO_ENTITY) {
+            return "";
+        }
+
+        return Locale::getDisplayRegion(
             Locale::country_code_to_locale($regionCode),
             $locale
         );
-
-        return ($regionCode === null || $regionCode == 'ZZ' || $regionCode === PhoneNumberUtil::REGION_CODE_FOR_NON_GEO_ENTITY) ? "" : $loc;
     }
 
     /**


### PR DESCRIPTION
When running `vendor/bin/phpunit -c phpunit.xml.dist Tests/libphonenumber/Tests/geocoding/PhoneNumberOfflineGeocoderTest.php` under PHP 5.5.14 a `Segmentation fault` is the result (Line 95 is the cause).

The problem is that `Locale::getDisplayRegion` is being called with the first argument being NULL.
