### PR TITLE
Move ext-intl from a requirement to a suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "exclude": ["Tests/", "build/", "/.travis.yml", "/build.xml", "phpunit.xml.dist", "libphonenumber-for-php.spec"]
     },
     "require": {
-        "ext-intl": "*",
         "ext-mbstring": "*"
     },
     "require-dev": {
@@ -40,6 +39,9 @@
         "phpunit/phpunit": "~4.0",
         "symfony/console": "~2.4",
         "satooshi/php-coveralls":  "~0.6"
+    },
+    "suggest": {
+        "ext-intl": "Required for the Offline Geocoder"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
ext-intl isn't a common extension to have installed, and for novices getting this extension enabled can be difficult. Since it's only required for the offline geocoder, I have moved it from a hard requirement which would break the install, to a suggestion which will warn the user if they don't have it and plan on using the offline geocoder.

This is related to the issue discussed in #43.
