### PR TITLE
Move ext-intl from a requirement to a suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A PHP library for parsing, formatting, storing and validating international phon
 
 The library can be installed via [composer](http://getcomposer.org/). You can also use any other [PSR-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md) compliant autoloader.
 
-The PECL [mbstring](http://php.net/mbstring) and [intl](http://php.net/intl) extensions are required for this library to be used.
+The PECL [mbstring](http://php.net/mbstring) extension is required for this library to be used.
 
 ```json
 {
@@ -98,6 +98,8 @@ echo $phoneUtil->formatOutOfCountryCallingNumber($swissNumberProto, "GB");
 
 ### Geocoder
 
+The PECL [intl](http://php.net/intl) extension is required for the geocoder to be used.
+
 ```php
 $phoneUtil = \libphonenumber\PhoneNumberUtil::getInstance();
 
@@ -152,6 +154,8 @@ var_dump($shortNumberInfo->connectsToEmergencyNumber("911123", "US"));
 ```
 
 ### Mapping Phone Numbers to carrier
+
+The PECL [intl](http://php.net/intl) extension is required for the carrier mapper to be used.
 
 ```php
 

--- a/Tests/libphonenumber/Tests/Issues/CodeCoverageTest.php
+++ b/Tests/libphonenumber/Tests/Issues/CodeCoverageTest.php
@@ -12,17 +12,10 @@ class CodeCoverageTest extends \PHPUnit_Framework_TestCase
      */
     private $phoneUtil;
 
-    /**
-     * @var PhoneNumberOfflineGeocoder
-     */
-    private $geocoder;
-
     public function setUp()
     {
         PhoneNumberUtil::resetInstance();
         $this->phoneUtil = PhoneNumberUtil::getInstance();
-
-        $this->geocoder = PhoneNumberOfflineGeocoder::getInstance();
     }
 
     public function testNullException()

--- a/Tests/libphonenumber/Tests/Issues/Issue17Test.php
+++ b/Tests/libphonenumber/Tests/Issues/Issue17Test.php
@@ -20,6 +20,10 @@ class Issue17Test extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if(!extension_loaded('intl')) {
+            $this->markTestSkipped('The intl extension must be installed');
+        }
+
         PhoneNumberUtil::resetInstance();
         PhoneNumberOfflineGeocoder::resetInstance();
         $this->phoneUtil = PhoneNumberUtil::getInstance();

--- a/Tests/libphonenumber/Tests/Issues/Issue23Test.php
+++ b/Tests/libphonenumber/Tests/Issues/Issue23Test.php
@@ -14,7 +14,7 @@ class Issue23Test extends \PHPUnit_Framework_TestCase
      */
     private $phoneUtil;
     /**
-     * @var PhoneNumberOfflineGeocoder
+     * @var PhoneNumberOfflineGeocoder|null
      */
     private $geocoder;
 
@@ -23,7 +23,9 @@ class Issue23Test extends \PHPUnit_Framework_TestCase
         PhoneNumberUtil::resetInstance();
         $this->phoneUtil = PhoneNumberUtil::getInstance();
 
-        $this->geocoder = PhoneNumberOfflineGeocoder::getInstance();
+        if(extension_loaded('intl')) {
+            $this->geocoder = PhoneNumberOfflineGeocoder::getInstance();
+        }
     }
 
     public function testTKGeoLocation()
@@ -34,6 +36,8 @@ class Issue23Test extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('TK', $this->phoneUtil->getRegionCodeForNumber($phoneNumber));
 
-        $this->assertEquals('Tokelau', $this->geocoder->getDescriptionForNumber($phoneNumber, 'en'));
+        if($this->geocoder instanceof PhoneNumberOfflineGeocoder) {
+            $this->assertEquals('Tokelau', $this->geocoder->getDescriptionForNumber($phoneNumber, 'en'));
+        }
     }
 }

--- a/Tests/libphonenumber/Tests/Issues/Issue36Test.php
+++ b/Tests/libphonenumber/Tests/Issues/Issue36Test.php
@@ -20,6 +20,10 @@ class Issue36Test extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if(!extension_loaded('intl')) {
+            $this->markTestSkipped('The intl extension must be installed');
+        }
+
         PhoneNumberUtil::resetInstance();
         PhoneNumberOfflineGeocoder::resetInstance();
         $this->phoneUtil = PhoneNumberUtil::getInstance();

--- a/Tests/libphonenumber/Tests/Issues/Issue44Test.php
+++ b/Tests/libphonenumber/Tests/Issues/Issue44Test.php
@@ -20,6 +20,10 @@ class Issue44Test extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if(!extension_loaded('intl')) {
+            $this->markTestSkipped('The intl extension must be installed');
+        }
+
         PhoneNumberUtil::resetInstance();
         $this->phoneUtil = PhoneNumberUtil::getInstance();
 

--- a/Tests/libphonenumber/Tests/Issues/LocaleTest.php
+++ b/Tests/libphonenumber/Tests/Issues/LocaleTest.php
@@ -29,6 +29,10 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if(!extension_loaded('intl')) {
+            $this->markTestSkipped('The intl extension must be installed');
+        }
+
         PhoneNumberUtil::resetInstance();
         PhoneNumberOfflineGeocoder::resetInstance();
         $this->phoneUtil = PhoneNumberUtil::getInstance();

--- a/Tests/libphonenumber/Tests/carrier/PhoneNumberToCarrierMapperTest.php
+++ b/Tests/libphonenumber/Tests/carrier/PhoneNumberToCarrierMapperTest.php
@@ -77,6 +77,10 @@ class PhoneNumberToCarrierMapperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if(!extension_loaded('intl')) {
+            $this->markTestSkipped('The intl extension must be installed');
+        }
+
         $this->carrierMapper = PhoneNumberToCarrierMapper::getInstance(self::TEST_META_DATA_FILE_PREFIX);
     }
 

--- a/Tests/libphonenumber/Tests/core/IntlTest.php
+++ b/Tests/libphonenumber/Tests/core/IntlTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace libphonenumber\Tests\core;
+
+use libphonenumber\geocoding\PhoneNumberOfflineGeocoder;
+use libphonenumber\PhoneNumberToCarrierMapper;
+
+/**
+ * Verifies that classes which require the Intl extension cannot be instantiated.
+ */
+class IntlTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (extension_loaded('intl')) {
+            $this->markTestSkipped('The intl extension must not be installed');
+        }
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The intl extension must be installed
+     */
+    public function testPhoneNumberOfflineGeocoder()
+    {
+        PhoneNumberOfflineGeocoder::getInstance();
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The intl extension must be installed
+     */
+    public function testPhoneNumberToCarrierMapper()
+    {
+        PhoneNumberToCarrierMapper::getInstance();
+    }
+}

--- a/Tests/libphonenumber/Tests/geocoding/PhoneNumberOfflineGeocoderTest.php
+++ b/Tests/libphonenumber/Tests/geocoding/PhoneNumberOfflineGeocoderTest.php
@@ -80,6 +80,10 @@ class PhoneNumberOfflineGeocoderTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if(!extension_loaded('intl')) {
+            $this->markTestSkipped('The intl extension must be installed');
+        }
+
         PhoneNumberOfflineGeocoder::resetInstance();
         $this->geocoder = PhoneNumberOfflineGeocoder::getInstance(self::TEST_META_DATA_FILE_PREFIX);
     }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "exclude": ["Tests/", "build/", "/.travis.yml", "/build.xml", "phpunit.xml.dist", "libphonenumber-for-php.spec"]
     },
     "require": {
-        "ext-intl": "*",
         "ext-mbstring": "*"
     },
     "require-dev": {
@@ -40,6 +39,9 @@
         "phpunit/phpunit": "~4.0",
         "symfony/console": "~2.4",
         "satooshi/php-coveralls":  "~0.6"
+    },
+    "suggest": {
+        "ext-intl": "To use the geocoder and carrier mapping"
     },
     "extra": {
         "branch-alias": {

--- a/src/libphonenumber/PhoneNumberToCarrierMapper.php
+++ b/src/libphonenumber/PhoneNumberToCarrierMapper.php
@@ -32,6 +32,10 @@ class PhoneNumberToCarrierMapper
 
     private function __construct($phonePrefixDataDirectory)
     {
+        if(!extension_loaded('intl')) {
+            throw new \RuntimeException('The intl extension must be installed');
+        }
+
         $this->prefixFileReader = new PrefixFileReader(dirname(__FILE__) . $phonePrefixDataDirectory);
         $this->phoneUtil = PhoneNumberUtil::getInstance();
     }

--- a/src/libphonenumber/geocoding/PhoneNumberOfflineGeocoder.php
+++ b/src/libphonenumber/geocoding/PhoneNumberOfflineGeocoder.php
@@ -27,6 +27,10 @@ class PhoneNumberOfflineGeocoder
 
     private function __construct($phonePrefixDataDirectory)
     {
+        if(!extension_loaded('intl')) {
+            throw new \RuntimeException('The intl extension must be installed');
+        }
+
         $this->phoneUtil = PhoneNumberUtil::getInstance();
 
         $this->prefixFileReader = new PrefixFileReader(dirname(__FILE__) . $phonePrefixDataDirectory);


### PR DESCRIPTION
Replaces #45.

I've tried to capture all places where the intl extension is required and throw an exception, and skip those tests. The only that I haven't covered is the Locale subclass, is there any reason that this extends the base Locale class? (Looks to me like it's just there for the static method.)

I'll change this commit once or twice to try and trigger a Travis build without the Intl extension.
