### PR TITLE
Update syntax mobile phone France

### DIFF
--- a/src/libphonenumber/data/PhoneNumberMetadata_FR.php
+++ b/src/libphonenumber/data/PhoneNumberMetadata_FR.php
@@ -20,7 +20,7 @@ return array (
   'mobile' => 
   array (
     'NationalNumberPattern' => '
-          6\\d{8}|
+          [6-7]\\d{8}|
           7[5-9]\\d{7}
         ',
     'PossibleNumberPattern' => '\\d{9}',


### PR DESCRIPTION
in France a telephone number may start with 06 or 07
