### PR TITLE
Patch Polish data to fix PHP7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: php
 matrix:
   allow_failures:
     - php: hhvm
-    - php: 7
 
 php:
   - 5.3

--- a/Tests/libphonenumber/Tests/Issues/PHP7Test.php
+++ b/Tests/libphonenumber/Tests/Issues/PHP7Test.php
@@ -1,0 +1,52 @@
+<?php
+
+
+namespace libphonenumber\Tests\Issues;
+
+
+use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberUtil;
+
+class PHP7Test extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PhoneNumberUtil
+     */
+    private $phoneUtil;
+
+    public function setUp()
+    {
+        PhoneNumberUtil::resetInstance();
+        $this->phoneUtil = PhoneNumberUtil::getInstance();
+    }
+
+    /**
+     * @param $number
+     * @dataProvider validPolishNumbers
+     */
+    public function testValidPolishNumbers($number)
+    {
+        $phoneNumber = $this->phoneUtil->parse($number, 'PL');
+
+        $this->assertTrue($this->phoneUtil->isValidNumber($phoneNumber));
+        $this->assertEquals($number, $this->phoneUtil->format($phoneNumber, PhoneNumberFormat::NATIONAL));
+    }
+
+    public function validPolishNumbers()
+    {
+        return array(
+            array('22 222 22 22'),
+            array('33 222 22 22'),
+            array('46 222 22 22'),
+            array('61 222 22 22'),
+            array('62 222 22 22'),
+            array('642 222 222'),
+            array('65 222 22 22'),
+            array('512 345 678'),
+            array('800 123 456'),
+            array('700 000 000'),
+            array('801 234 567'),
+            array('91 000 00 00'),
+        );
+    }
+}

--- a/build.xml
+++ b/build.xml
@@ -85,13 +85,19 @@
     </target>
 
     <target name="git-pull">
-        <available file='results' type='dir' property="git.path.exists"/>
+        <available file="${git.path}" type="dir" property="git.path.exists" />
         <if>
-            <isfalse value="${git.path.exists}"/>
+            <or>
+                <not>
+                    <isset property="git.path.exists" />
+                </not>
+                <isfalse value="${git.path.exists}"/>
+            </or>
             <then>
+                <echo>Cloning repository</echo>
                 <gitclone
-                        repository="${git.url}"
-                        targetPath="${git.path}"/>
+                    repository="${git.url}"
+                    targetPath="${git.path}"/>
             </then>
         </if>
 
@@ -99,8 +105,20 @@
         <echo message="Pulling Git project @ ${metadata.version}"/>
 
         <gitcheckout
-                repository="${git.path}"
-                branchname="${metadata.version}" quiet="false"/>
+            repository="${git.path}"
+            branchname="${metadata.version}" quiet="false" force="true" />
+
+        <foreach param="filename" absparam="absfilename" target="apply-data-patch">
+            <fileset dir="build/data-patches">
+                <include name="*.patch" />
+            </fileset>
+        </foreach>
+    </target>
+
+    <target name="apply-data-patch">
+        <echo>Applying patch ${filename}</echo>
+        <resolvepath propertyName="fullpath" file="${absfilename}"/>
+        <patch patchfile="${fullpath}" dir="${git.path}/" strip="1" />
     </target>
 
     <target name="build-test-metadata" description="Build test Phone Metadata" depends="git-pull">

--- a/build/data-patches/001-PHP7-PL.patch
+++ b/build/data-patches/001-PHP7-PL.patch
@@ -1,0 +1,13 @@
+diff --git a/resources/PhoneNumberMetadata.xml b/resources/PhoneNumberMetadata.xml
+index a53b48d..820598c 100644
+--- a/resources/PhoneNumberMetadata.xml
++++ b/resources/PhoneNumberMetadata.xml
+@@ -19031,7 +19031,7 @@
+       <generalDesc>
+         <nationalNumberPattern>
+           [12]\d{6,8}|
+-          [3-57-9]\d{8}|
++          (?:[3-5]|[7-9])\d{8}|
+           6\d{5,8}
+         </nationalNumberPattern>
+         <possibleNumberPattern>\d{6,9}</possibleNumberPattern>

--- a/src/libphonenumber/data/PhoneNumberMetadata_PL.php
+++ b/src/libphonenumber/data/PhoneNumberMetadata_PL.php
@@ -10,7 +10,7 @@ return array (
   array (
     'NationalNumberPattern' => '
           [12]\\d{6,8}|
-          [3-57-9]\\d{8}|
+          (?:[3-5]|[7-9])\\d{8}|
           6\\d{5,8}
         ',
     'PossibleNumberPattern' => '\\d{6,9}',


### PR DESCRIPTION
Add phing command to patch the source data, this changes the regex for Poland
which allows the PHP7 tests to pass

Works around #79 and [PHP Bug #70304](https://bugs.php.net/bug.php?id=70304)

Thanks to [/u/OzzyGiritli](https://www.reddit.com/user/OzzyGiritli) for
the idea to split the Regex.