### PR TITLE
allow extended PhoneNumberUtil instance

### DIFF
--- a/src/libphonenumber/PhoneNumberUtil.php
+++ b/src/libphonenumber/PhoneNumberUtil.php
@@ -396,7 +396,7 @@ class PhoneNumberUtil
                 $metadataSource = new MultiFileMetadataSourceImpl($metadataLoader, __DIR__ . '/data/' . $baseFileLocation);
             }
 
-            static::$instance = new PhoneNumberUtil($metadataSource, $countryCallingCodeToRegionCodeMap);
+            static::$instance = new static($metadataSource, $countryCallingCodeToRegionCodeMap);
         }
         return static::$instance;
     }


### PR DESCRIPTION
A recent requirement was to reject numbers containing alphanumeric characters. currently `+49 123 456-xxxx` gets parsed successfully, leading to a `PhoneNumber` instance containing `nationalNumber = 1234569999` which is not what we expected.

I didn't check all the existing rules & behavior of the underlying google library, but we wanted an Exception in this case. Trying to extend `PhoneNumberUtil` was a bit more complicated since `PhoneNumberUtil::getInstance` explicitly does `new PhoneNumberUtil` which means we had to copy the whole method just to ensure we got our own instance back.

changing `new PhoneNumberUtil` to `new static` would allow such an extension w/o any further code, w/o breaking compatibility.

@giggsey i had three, imo unrelated, test failures caused by 'Cocos [Keeling] Islands', 'Myanmar (Burma)' and 'St. Vincent & Grenadines'