### PR TITLE
PhoneNumberUtil::getRegionCodesForCountryCode fix return type hint

### DIFF
--- a/src/libphonenumber/PhoneNumberUtil.php
+++ b/src/libphonenumber/PhoneNumberUtil.php
@@ -1938,7 +1938,7 @@ class PhoneNumberUtil
      * non-geographical country calling codes, the region code 001 is returned. Also, in the case
      * of no region code being found, an empty list is returned.
      * @param int $countryCallingCode
-     * @return array|null
+     * @return array
      */
     public function getRegionCodesForCountryCode($countryCallingCode)
     {


### PR DESCRIPTION
The method always returns an array, please keep the SCA's happy :)