### PR TITLE
Exclude "/src/geocoding/data/" from autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,9 @@
   "autoload": {
     "psr-4": {
       "libphonenumber\\": "src/"
-    }
+    },
+    "exclude-from-classmap": ["/src/geocoding/data/"]
+
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,12 @@
     "psr-4": {
       "libphonenumber\\": "src/"
     },
-    "exclude-from-classmap": ["/src/geocoding/data/"]
+    "exclude-from-classmap": [
+        "/src/data/",
+        "/src/carrier/data/",
+        "/src/geocoding/data/",
+        "/src/timezone/data/"
+    ]
 
   },
   "autoload-dev": {


### PR DESCRIPTION
 I think "/src/geocoding/data/" can be excluded from autoload since it doesn't contains any thing needs to be autoloaded. 
Another reason is I'm sort of implementing my own autoloading mechanism with parsing. And the files under "/src/geocoding/data/" take very long time to parse. 