### PR TITLE
Default null for for parser default region

### DIFF
--- a/src/PhoneNumberUtil.php
+++ b/src/PhoneNumberUtil.php
@@ -2993,7 +2993,7 @@ class PhoneNumberUtil
      *
      * @param string $numberToParse number that we are attempting to parse. This can contain formatting
      *                          such as +, ( and -, as well as a phone number extension.
-     * @param string $defaultRegion region that we are expecting the number to be from. This is only used
+     * @param string|null $defaultRegion region that we are expecting the number to be from. This is only used
      *                          if the number being parsed is not written in international format.
      *                          The country_code for the number in this case would be stored as that
      *                          of the default region supplied. If the number is guaranteed to
@@ -3007,7 +3007,7 @@ class PhoneNumberUtil
      *                               and the number is not in international format (does not start
      *                               with +)
      */
-    public function parse($numberToParse, $defaultRegion, PhoneNumber $phoneNumber = null, $keepRawInput = false)
+    public function parse($numberToParse, $defaultRegion = null, PhoneNumber $phoneNumber = null, $keepRawInput = false)
     {
         if ($phoneNumber === null) {
             $phoneNumber = new PhoneNumber();

--- a/tests/core/PhoneNumberUtilTest.php
+++ b/tests/core/PhoneNumberUtilTest.php
@@ -3444,6 +3444,15 @@ class PhoneNumberUtilTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($threeZeros, $this->phoneUtil->parse("0000", RegionCode::AU));
     }
 
+    public function testParseHasDefaultNullRegion()
+    {
+        $ukNumber = '+441174960123';
+
+        $phone = $this->phoneUtil->parse($ukNumber);
+
+        $this->assertTrue($this->phoneUtil->isValidNumber($phone));
+    }
+
     public function testCountryWithNoNumberDesc()
     {
         // Andorra is a country where we don't have PhoneNumberDesc info in the metadata.


### PR DESCRIPTION
Because a lot of duplications in code of `null` value provided in parser I've thought about making it default. 

```php
$phoneUtil = \libphonenumber\PhoneNumberUtil::getInstance();
$phone = $phoneUtil->parse($number, null);
```

It will work by this way:
```php
$phoneUtil = \libphonenumber\PhoneNumberUtil::getInstance();
$phone = $phoneUtil->parse($number);
```