### PR TITLE
Fixed PhoneNumber::unserialize

### DIFF
--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -597,6 +597,8 @@ class PhoneNumber implements \Serializable
             $this->preferredDomesticCarrierCode
         ) = $data;
 
-        $this->hasNumberOfLeadingZeros = true;
+        if ($this->numberOfLeadingZeros > 1) {
+            $this->hasNumberOfLeadingZeros = true;
+        }
     }
 }

--- a/tests/core/PhoneNumberTest.php
+++ b/tests/core/PhoneNumberTest.php
@@ -96,4 +96,12 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($numberA, $numberB);
     }
+
+    public function testUnserialize()
+    {
+        $numberA = new PhoneNumber();
+        $numberB = new PhoneNumber();
+
+        $this->assertEquals($numberA, \unserialize(\serialize($numberB)));
+    }
 }


### PR DESCRIPTION
I was using `assertEquals` in some tests that was not passing because of the nested phone number which has not the same state after unserialization.