### PR TITLE
Remove incorrect intl requirement from docs

### DIFF
--- a/docs/PhoneNumberOfflineGeocoder.md
+++ b/docs/PhoneNumberOfflineGeocoder.md
@@ -1,7 +1,5 @@
 # PhoneNumberOfflineGeocoder
 
-The Phone Number Geocoder requires the PHP [intl](http://php.net/intl) extension.
-
 ## Getting Started
 
 As with [PhoneNumberUtil](PhoneNumberUtil.md), the Phone Number Geocoder uses a singleton.

--- a/docs/PhoneNumberToCarrierMapper.md
+++ b/docs/PhoneNumberToCarrierMapper.md
@@ -1,7 +1,5 @@
 # PhoneNumberToCarrierMapper
 
-The Phone Number Carrier Mapper requires the PHP [intl](http://php.net/intl) extension.
-
 ## Getting Started
 
 As with [PhoneNumberUtil](PhoneNumberUtil.md), the Phone Number Carrier Mapper uses a singleton.


### PR DESCRIPTION
The extension hasn't been required for a while now, the docs should match this.