### PR TITLE
Wrong word for United States In Korean

### DIFF
--- a/docs/PhoneNumberOfflineGeocoder.md
+++ b/docs/PhoneNumberOfflineGeocoder.md
@@ -44,7 +44,7 @@ var_dump($geoCoder->getDescriptionForNumber($usNumber, 'en_GB', 'US'));
 // string(14) "Mountain View, CA"
 
 var_dump($geoCoder->getDescriptionForNumber($usNumber, 'ko-KR', 'US'));
-// string(6) "영국" (Korean for United States)
+// string(6) "미국" (Korean for United States)
 ```
 
 ## `getDescriptionForValidNumber()`


### PR DESCRIPTION
It should be "미국"