### PR TITLE
Fix bug when calling isPossibleNumber with string, null

### DIFF
--- a/src/PhoneNumberUtil.php
+++ b/src/PhoneNumberUtil.php
@@ -3475,7 +3475,7 @@ class PhoneNumberUtil
      */
     public function isPossibleNumber($number, $regionDialingFrom = null)
     {
-        if ($regionDialingFrom !== null && is_string($number)) {
+        if (is_string($number)) {
             try {
                 return $this->isPossibleNumber($this->parse($number, $regionDialingFrom));
             } catch (NumberParseException $e) {

--- a/tests/Issues/Issue360Test.php
+++ b/tests/Issues/Issue360Test.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace libphonenumber\Tests\Issues;
+
+use libphonenumber\PhoneNumberUtil;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test that you can not pass a string and null to isPossibleNumber
+ * @see https://github.com/giggsey/libphonenumber-for-php/issues/360
+ * @package libphonenumber\Tests\Issues
+ */
+class Issue360Test extends TestCase
+{
+    public function testNullRegion()
+    {
+        $this->assertTrue(PhoneNumberUtil::getInstance()->isPossibleNumber('+441174960123', null));
+    }
+}


### PR DESCRIPTION
PHP doesn't allow method overloading, so we have to merge `isPossibleNumber(PhoneNumber $number)` and `isPossibleNumber(string $number, string $region)`.

We were incorrectly checking if the second parameter was not null, when we only needed to check if the first param was a PhoneNumber or a string.

Fixes #360