### PR TITLE
updated sg phone number format

### DIFF
--- a/src/data/PhoneNumberMetadata_SG.php
+++ b/src/data/PhoneNumberMetadata_SG.php
@@ -39,7 +39,7 @@ return array (
   ),
   'mobile' => 
   array (
-    'NationalNumberPattern' => '(?:8(?:[1-8]\\d\\d|9(?:[01]\\d|2[1-8]|3[0-4]))|9[0-8]\\d\\d)\\d{4}',
+    'NationalNumberPattern' => '(?:8(?:[1-9]\\d{2})|9[0-8]\\d\\d)\\d{4}',
     'ExampleNumber' => '81234567',
     'PossibleLength' => 
     array (


### PR DESCRIPTION
Current we have users in Singapore that uses phone number in `8939xxxx` format and it was not accepted.

I have updated the format in this PR. Please have a look, thanks