### PR TITLE
PhoneNumberUtil::getMetadata* methods can return null

### DIFF
--- a/src/PhoneNumberUtil.php
+++ b/src/PhoneNumberUtil.php
@@ -809,7 +809,7 @@ class PhoneNumberUtil
      * Returns the metadata for the given region code or {@code null} if the region code is invalid
      * or unknown.
      * @param string $regionCode
-     * @return PhoneMetadata
+     * @return null|PhoneMetadata
      */
     public function getMetadataForRegion($regionCode)
     {
@@ -1027,7 +1027,7 @@ class PhoneNumberUtil
     /**
      * @param int $countryCallingCode
      * @param string $regionCode
-     * @return PhoneMetadata
+     * @return null|PhoneMetadata
      */
     protected function getMetadataForRegionOrCallingCode($countryCallingCode, $regionCode)
     {
@@ -1037,7 +1037,7 @@ class PhoneNumberUtil
 
     /**
      * @param int $countryCallingCode
-     * @return PhoneMetadata
+     * @return null|PhoneMetadata
      */
     public function getMetadataForNonGeographicalRegion($countryCallingCode)
     {


### PR DESCRIPTION
If the region code or country calling code are invalid, the getMetadata* methods will return null