### PR TITLE
French mobile phone number can start with a 7

### DIFF
--- a/src/data/PhoneNumberMetadata_FR.php
+++ b/src/data/PhoneNumberMetadata_FR.php
@@ -36,7 +36,7 @@ return array (
   ),
   'mobile' => 
   array (
-    'NationalNumberPattern' => '700\\d{6}|(?:6\\d|7[3-9])\\d{7}',
+    'NationalNumberPattern' => '700\\d{6}|(?:[6|7]\\d|7[3-9])\\d{7}',
     'ExampleNumber' => '612345678',
     'PossibleLength' => 
     array (


### PR DESCRIPTION
:wave: Hi there, I propose an evolution for french mobile phone regex, since 2010, french mobile phone can start too with 7 _(before, it was only with 6)_

Source : https://en.arcep.fr/news/press-releases/p/n/arcep-opens-the-07-range-for-mobile-services.html

`ARCEP has adopted a decision which would open an initial range of numbers beginning with "07" for mobile services.`

french mobile phone who start with 07 starts with 075, 076, 077, 078, and 079 => we should make the regex evolved again for only allow those start parts