### PR TITLE
Fix French mobile number pattern

### DIFF
--- a/src/data/PhoneNumberMetadata_FR.php
+++ b/src/data/PhoneNumberMetadata_FR.php
@@ -12,131 +12,131 @@
 
 
 return array (
-  'generalDesc' => 
+  'generalDesc' =>
   array (
     'NationalNumberPattern' => '[1-9]\\d{8}',
-    'PossibleLength' => 
+    'PossibleLength' =>
     array (
       0 => 9,
     ),
-    'PossibleLengthLocalOnly' => 
+    'PossibleLengthLocalOnly' =>
     array (
     ),
   ),
-  'fixedLine' => 
+  'fixedLine' =>
   array (
     'NationalNumberPattern' => '(?:[1-35]\\d|4[1-9])\\d{7}',
     'ExampleNumber' => '123456789',
-    'PossibleLength' => 
+    'PossibleLength' =>
     array (
     ),
-    'PossibleLengthLocalOnly' => 
+    'PossibleLengthLocalOnly' =>
     array (
     ),
   ),
-  'mobile' => 
+  'mobile' =>
   array (
-    'NationalNumberPattern' => '(?:6(?:[0-24-8]\\d|3[0-8]|9[589])|7(?:00|[3-9]\\d))\\d{6}',
+    'NationalNumberPattern' => '(?:[6-7](?:[0-24-8]\\d|3[0-8]|9[589])|7(?:00|[3-9]\\d))\\d{6}',
     'ExampleNumber' => '612345678',
-    'PossibleLength' => 
+    'PossibleLength' =>
     array (
     ),
-    'PossibleLengthLocalOnly' => 
+    'PossibleLengthLocalOnly' =>
     array (
     ),
   ),
-  'tollFree' => 
+  'tollFree' =>
   array (
     'NationalNumberPattern' => '80[0-5]\\d{6}',
     'ExampleNumber' => '801234567',
-    'PossibleLength' => 
+    'PossibleLength' =>
     array (
     ),
-    'PossibleLengthLocalOnly' => 
+    'PossibleLengthLocalOnly' =>
     array (
     ),
   ),
-  'premiumRate' => 
+  'premiumRate' =>
   array (
     'NationalNumberPattern' => '836(?:0[0-36-9]|[1-9]\\d)\\d{4}|8(?:1[2-9]|2[2-47-9]|3[0-57-9]|[569]\\d|8[0-35-9])\\d{6}',
     'ExampleNumber' => '891123456',
-    'PossibleLength' => 
+    'PossibleLength' =>
     array (
     ),
-    'PossibleLengthLocalOnly' => 
+    'PossibleLengthLocalOnly' =>
     array (
     ),
   ),
-  'sharedCost' => 
+  'sharedCost' =>
   array (
     'NationalNumberPattern' => '8(?:1[01]|2[0156]|84)\\d{6}',
     'ExampleNumber' => '884012345',
-    'PossibleLength' => 
+    'PossibleLength' =>
     array (
     ),
-    'PossibleLengthLocalOnly' => 
+    'PossibleLengthLocalOnly' =>
     array (
     ),
   ),
-  'personalNumber' => 
+  'personalNumber' =>
   array (
-    'PossibleLength' => 
+    'PossibleLength' =>
     array (
       0 => -1,
     ),
-    'PossibleLengthLocalOnly' => 
+    'PossibleLengthLocalOnly' =>
     array (
     ),
   ),
-  'voip' => 
+  'voip' =>
   array (
     'NationalNumberPattern' => '9\\d{8}',
     'ExampleNumber' => '912345678',
-    'PossibleLength' => 
+    'PossibleLength' =>
     array (
     ),
-    'PossibleLengthLocalOnly' => 
+    'PossibleLengthLocalOnly' =>
     array (
     ),
   ),
-  'pager' => 
+  'pager' =>
   array (
-    'PossibleLength' => 
+    'PossibleLength' =>
     array (
       0 => -1,
     ),
-    'PossibleLengthLocalOnly' => 
+    'PossibleLengthLocalOnly' =>
     array (
     ),
   ),
-  'uan' => 
+  'uan' =>
   array (
     'NationalNumberPattern' => '80[6-9]\\d{6}',
     'ExampleNumber' => '806123456',
-    'PossibleLength' => 
+    'PossibleLength' =>
     array (
     ),
-    'PossibleLengthLocalOnly' => 
-    array (
-    ),
-  ),
-  'voicemail' => 
-  array (
-    'PossibleLength' => 
-    array (
-      0 => -1,
-    ),
-    'PossibleLengthLocalOnly' => 
+    'PossibleLengthLocalOnly' =>
     array (
     ),
   ),
-  'noInternationalDialling' => 
+  'voicemail' =>
   array (
-    'PossibleLength' => 
+    'PossibleLength' =>
     array (
       0 => -1,
     ),
-    'PossibleLengthLocalOnly' => 
+    'PossibleLengthLocalOnly' =>
+    array (
+    ),
+  ),
+  'noInternationalDialling' =>
+  array (
+    'PossibleLength' =>
+    array (
+      0 => -1,
+    ),
+    'PossibleLengthLocalOnly' =>
     array (
     ),
   ),
@@ -146,13 +146,13 @@ return array (
   'nationalPrefix' => '0',
   'nationalPrefixForParsing' => '0',
   'sameMobileAndFixedLinePattern' => false,
-  'numberFormat' => 
+  'numberFormat' =>
   array (
-    0 => 
+    0 =>
     array (
       'pattern' => '(\\d{4})',
       'format' => '$1',
-      'leadingDigitsPatterns' => 
+      'leadingDigitsPatterns' =>
       array (
         0 => '10',
       ),
@@ -160,11 +160,11 @@ return array (
       'domesticCarrierCodeFormattingRule' => '',
       'nationalPrefixOptionalWhenFormatting' => false,
     ),
-    1 => 
+    1 =>
     array (
       'pattern' => '(\\d{3})(\\d{3})',
       'format' => '$1 $2',
-      'leadingDigitsPatterns' => 
+      'leadingDigitsPatterns' =>
       array (
         0 => '1',
       ),
@@ -172,11 +172,11 @@ return array (
       'domesticCarrierCodeFormattingRule' => '',
       'nationalPrefixOptionalWhenFormatting' => false,
     ),
-    2 => 
+    2 =>
     array (
       'pattern' => '(\\d{3})(\\d{2})(\\d{2})(\\d{2})',
       'format' => '$1 $2 $3 $4',
-      'leadingDigitsPatterns' => 
+      'leadingDigitsPatterns' =>
       array (
         0 => '8',
       ),
@@ -184,11 +184,11 @@ return array (
       'domesticCarrierCodeFormattingRule' => '',
       'nationalPrefixOptionalWhenFormatting' => false,
     ),
-    3 => 
+    3 =>
     array (
       'pattern' => '(\\d)(\\d{2})(\\d{2})(\\d{2})(\\d{2})',
       'format' => '$1 $2 $3 $4 $5',
-      'leadingDigitsPatterns' => 
+      'leadingDigitsPatterns' =>
       array (
         0 => '[1-79]',
       ),
@@ -197,13 +197,13 @@ return array (
       'nationalPrefixOptionalWhenFormatting' => false,
     ),
   ),
-  'intlNumberFormat' => 
+  'intlNumberFormat' =>
   array (
-    0 => 
+    0 =>
     array (
       'pattern' => '(\\d{3})(\\d{2})(\\d{2})(\\d{2})',
       'format' => '$1 $2 $3 $4',
-      'leadingDigitsPatterns' => 
+      'leadingDigitsPatterns' =>
       array (
         0 => '8',
       ),
@@ -211,11 +211,11 @@ return array (
       'domesticCarrierCodeFormattingRule' => '',
       'nationalPrefixOptionalWhenFormatting' => false,
     ),
-    1 => 
+    1 =>
     array (
       'pattern' => '(\\d)(\\d{2})(\\d{2})(\\d{2})(\\d{2})',
       'format' => '$1 $2 $3 $4 $5',
-      'leadingDigitsPatterns' => 
+      'leadingDigitsPatterns' =>
       array (
         0 => '[1-79]',
       ),


### PR DESCRIPTION
Hello, 
I'm currently using your package on my website and I realize that I can't validate French phone numbers starting with 07.

As you can see, the prefix exists in the list of cell phone numbers: https://en.wikipedia.org/wiki/Telephone_numbers_in_France.

Thank you for the work done anyway. 

Have a nice day.