### PR TITLE
Upstream metadata changes from Google for v8.12.15

### DIFF
--- a/METADATA-VERSION.txt
+++ b/METADATA-VERSION.txt
@@ -2,4 +2,4 @@
 # It can be a commit, branch or tag of the https://github.com/google/libphonenumber project
 #
 # For more information, look at the phing tasks in build.xml
-v8.12.14
+v8.12.15

--- a/src/carrier/data/en/224.php
+++ b/src/carrier/data/en/224.php
@@ -12,6 +12,7 @@
 
 return array (
   22460 => 'Sotelgui',
+  22461 => 'Orange',
   22462 => 'Orange',
   22463 => 'Intercel',
   22465 => 'Cellcom',

--- a/src/carrier/data/en/230.php
+++ b/src/carrier/data/en/230.php
@@ -18,6 +18,7 @@ return array (
   230529 => 'MTML',
   23054 => 'Emtel',
   2305471 => 'Cellplus',
+  23055 => 'Emtel',
   23057 => 'Cellplus',
   230571 => 'Emtel',
   230572 => 'Emtel',

--- a/src/carrier/data/en/254.php
+++ b/src/carrier/data/en/254.php
@@ -13,7 +13,9 @@
 return array (
   25410 => 'Airtel',
   25411 => 'Safaricom',
-  25412 => 'Telkom',
+  254120 => 'Telkom',
+  254121 => 'Infura',
+  254124 => 'Finserve',
   25470 => 'Safaricom',
   25471 => 'Safaricom',
   25472 => 'Safaricom',

--- a/src/carrier/data/en/65.php
+++ b/src/carrier/data/en/65.php
@@ -13,6 +13,7 @@
 return array (
   65801 => 'TPG',
   658018 => 'SingTel',
+  658019 => 'SingTel',
   65802 => 'SingTel',
   65803 => 'SingTel',
   6581 => 'StarHub',
@@ -324,6 +325,9 @@ return array (
   658932 => 'TPG',
   658933 => 'TPG',
   658934 => 'TPG',
+  658935 => 'M1',
+  658936 => 'M1',
+  658937 => 'M1',
   658938 => 'SingTel',
   658939 => 'SingTel',
   658940 => 'SingTel',

--- a/src/data/PhoneNumberMetadata_GN.php
+++ b/src/data/PhoneNumberMetadata_GN.php
@@ -38,7 +38,7 @@ return array (
   ),
   'mobile' => 
   array (
-    'NationalNumberPattern' => '6[02356]\\d{7}',
+    'NationalNumberPattern' => '6[0-356]\\d{7}',
     'ExampleNumber' => '601123456',
     'PossibleLength' => 
     array (

--- a/src/data/PhoneNumberMetadata_KE.php
+++ b/src/data/PhoneNumberMetadata_KE.php
@@ -42,7 +42,7 @@ return array (
   ),
   'mobile' => 
   array (
-    'NationalNumberPattern' => '(?:1(?:0[0-6]|1[0-5]|20)|7\\d\\d)\\d{6}',
+    'NationalNumberPattern' => '(?:1(?:0[0-6]|1[0-5]|2[014])|7\\d\\d)\\d{6}',
     'ExampleNumber' => '712123456',
     'PossibleLength' => 
     array (

--- a/src/data/PhoneNumberMetadata_MU.php
+++ b/src/data/PhoneNumberMetadata_MU.php
@@ -37,7 +37,7 @@ return array (
   ),
   'mobile' => 
   array (
-    'NationalNumberPattern' => '5(?:4(?:2[1-389]|7[1-9])|87[15-8])\\d{4}|5(?:2[5-9]|4[3-589]|7\\d|8[0-689]|9[0-8])\\d{5}',
+    'NationalNumberPattern' => '5(?:4(?:2[1-389]|7[1-9])|87[15-8])\\d{4}|5(?:2[5-9]|4[3-589]|5[1-9]|7\\d|8[0-689]|9[0-8])\\d{5}',
     'ExampleNumber' => '52512345',
     'PossibleLength' => 
     array (

--- a/src/data/PhoneNumberMetadata_SG.php
+++ b/src/data/PhoneNumberMetadata_SG.php
@@ -39,7 +39,7 @@ return array (
   ),
   'mobile' => 
   array (
-    'NationalNumberPattern' => '(?:8(?:0(?:1[0-8]|2[7-9]|3[01])|[1-8]\\d\\d|9(?:[0-24]\\d|3[0-489]|5[0-2]))|9[0-8]\\d\\d)\\d{4}',
+    'NationalNumberPattern' => '(?:8(?:0(?:1\\d|2[7-9]|3[01])|[1-8]\\d\\d|9(?:[0-4]\\d|5[0-2]))|9[0-8]\\d\\d)\\d{4}',
     'ExampleNumber' => '81234567',
     'PossibleLength' => 
     array (


### PR DESCRIPTION
 - Updated phone metadata for region code(s): GN, KE, MU, SG
 - Updated carrier data for country calling code(s):
   65 (en), 224 (en), 230 (en), 254 (en)
