### PR TITLE
Fix serialization/deserialization regression

### DIFF
--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -587,6 +587,11 @@ class PhoneNumber implements \Serializable
      */
     public function unserialize($serialized)
     {
+        if (is_string($serialized) && $serialized[0] === 'C') {
+            $this->__unserialize($serialized);
+            return;
+        }
+
         $this->__unserialize(unserialize($serialized));
     }
 

--- a/tests/Issues/Issue475Test.php
+++ b/tests/Issues/Issue475Test.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace libphonenumber\Tests\Issues;
+
+use libphonenumber\PhoneNumber;
+use PHPUnit\Framework\TestCase;
+
+class Issue475Test extends TestCase
+{
+    public function testSerialization()
+    {
+        $numberA = new PhoneNumber();
+        if (PHP_VERSION_ID >= 70000) {
+            self::assertSame('O:26:"libphonenumber\PhoneNumber":8:{i:0;N;i:1;N;i:2;N;i:3;N;i:4;i:1;i:5;N;i:6;i:4;i:7;N;}', serialize($numberA));
+        } else {
+            self::assertSame('C:26:"libphonenumber\PhoneNumber":58:{a:8:{i:0;N;i:1;N;i:2;N;i:3;N;i:4;i:1;i:5;N;i:6;i:4;i:7;N;}}', serialize($numberA));
+        }
+    }
+
+    public function testDeserializationOldFormat()
+    {
+        $number = unserialize('C:26:"libphonenumber\PhoneNumber":58:{a:8:{i:0;N;i:1;N;i:2;N;i:3;N;i:4;i:1;i:5;N;i:6;i:4;i:7;N;}}');
+        self::assertInstanceOf('libphonenumber\PhoneNumber', $number);
+    }
+
+    public function testDeserializationNewFormat()
+    {
+        $number = unserialize('O:26:"libphonenumber\PhoneNumber":8:{i:0;N;i:1;N;i:2;N;i:3;N;i:4;i:1;i:5;N;i:6;i:4;i:7;N;}');
+        self::assertInstanceOf('libphonenumber\PhoneNumber', $number);
+    }
+}


### PR DESCRIPTION
If a libphonenumber\PhoneNumber has been stored in a serialized
representation, deserialization will fail due to the changed format.
This allows both to continue going forward

Fixes #475