### PR TITLE
Update `PhoneNumberUtil::isValidRegionCode()` to work the same as javascript version

### DIFF
--- a/src/PhoneNumberUtil.php
+++ b/src/PhoneNumberUtil.php
@@ -894,7 +894,7 @@ class PhoneNumberUtil
      */
     protected function isValidRegionCode($regionCode)
     {
-        return $regionCode !== null && in_array($regionCode, $this->supportedRegions);
+        return $regionCode !== null && !is_numeric($regionCode) && in_array(strtoupper($regionCode), $this->supportedRegions);
     }
 
     /**


### PR DESCRIPTION
The google/libphonenumber javascript version has been updated such that it can both take lowercase/uppercase strings and also ensure that numeric regionCodes are not counted as valid.

See https://github.com/google/libphonenumber/blob/master/javascript/i18n/phonenumbers/phonenumberutil.js#L1658

See #480 for more info.