### PR TITLE
Prevent null from reaching `strtoupper` in `ShortNumberInfo`

### DIFF
--- a/src/ShortNumberInfo.php
+++ b/src/ShortNumberInfo.php
@@ -92,6 +92,10 @@ class ShortNumberInfo
      */
     protected function regionDialingFromMatchesNumber(PhoneNumber $number, $regionDialingFrom)
     {
+        if ($regionDialingFrom === null || $regionDialingFrom === '') {
+            return false;
+        }
+
         $regionCodes = $this->getRegionCodesForCountryCode($number->getCountryCode());
 
         return in_array(strtoupper($regionDialingFrom), $regionCodes);

--- a/tests/core/ShortNumberInfoTest.php
+++ b/tests/core/ShortNumberInfoTest.php
@@ -440,4 +440,10 @@ class ShortNumberInfoTest extends TestCase
             $this->fail('Test input data should always parse correctly: ' . $number . ' (' . $regionCode . ')');
         }
     }
+
+    public function testThatANullRegionCodeDoesNotCauseDeprecationWarning()
+    {
+        $validRegularNumber = $this->parse('01234 567 890', 'GB');
+        $this->assertFalse($this->shortInfo->isValidShortNumber($validRegularNumber));
+    }
 }


### PR DESCRIPTION
With a valid, regular land-line number given to `ShortNumberInfo::isValidShortNumber(PhoneNumber)`, a deprecation notice is issued for the null parameter value to `strtoupper` when it reaches `regionDialingFromMatchesNumber`.