### PR TITLE
Simplified PhoneNumber instance comparison and improved performance

### DIFF
--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -512,6 +512,10 @@ class PhoneNumber implements \Serializable
      */
     public function equals(PhoneNumber $other)
     {
+        if ($this === $other) {
+            return true;
+        }
+
         $sameType = get_class($other) == get_class($this);
         $sameCountry = $this->hasCountryCode() == $other->hasCountryCode() &&
             (!$this->hasCountryCode() || $this->getCountryCode() == $other->getCountryCode());

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -516,7 +516,6 @@ class PhoneNumber implements \Serializable
             return true;
         }
 
-        $sameType = get_class($other) == get_class($this);
         $sameCountry = $this->hasCountryCode() == $other->hasCountryCode() &&
             (!$this->hasCountryCode() || $this->getCountryCode() == $other->getCountryCode());
         $sameNational = $this->hasNationalNumber() == $other->hasNationalNumber() &&
@@ -533,7 +532,7 @@ class PhoneNumber implements \Serializable
         $samePrefCar = $this->hasPreferredDomesticCarrierCode() == $other->hasPreferredDomesticCarrierCode() &&
             (!$this->hasPreferredDomesticCarrierCode() || $this->getPreferredDomesticCarrierCode(
             ) == $other->getPreferredDomesticCarrierCode());
-        return $sameType && $sameCountry && $sameNational && $sameExt && $sameLead && $sameZeros && $sameRaw && $sameCountrySource && $samePrefCar;
+        return $sameCountry && $sameNational && $sameExt && $sameLead && $sameZeros && $sameRaw && $sameCountrySource && $samePrefCar;
     }
 
     /**

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -516,23 +516,14 @@ class PhoneNumber implements \Serializable
             return true;
         }
 
-        $sameCountry = $this->hasCountryCode() == $other->hasCountryCode() &&
-            (!$this->hasCountryCode() || $this->getCountryCode() == $other->getCountryCode());
-        $sameNational = $this->hasNationalNumber() == $other->hasNationalNumber() &&
-            (!$this->hasNationalNumber() || $this->getNationalNumber() == $other->getNationalNumber());
-        $sameExt = $this->hasExtension() == $other->hasExtension() &&
-            (!$this->hasExtension() || $this->getExtension() == $other->getExtension());
-        $sameLead = $this->hasItalianLeadingZero() == $other->hasItalianLeadingZero() &&
-            (!$this->hasItalianLeadingZero() || $this->isItalianLeadingZero() == $other->isItalianLeadingZero());
-        $sameZeros = $this->getNumberOfLeadingZeros() == $other->getNumberOfLeadingZeros();
-        $sameRaw = $this->hasRawInput() == $other->hasRawInput() &&
-            (!$this->hasRawInput() || $this->getRawInput() == $other->getRawInput());
-        $sameCountrySource = $this->hasCountryCodeSource() == $other->hasCountryCodeSource() &&
-            (!$this->hasCountryCodeSource() || $this->getCountryCodeSource() == $other->getCountryCodeSource());
-        $samePrefCar = $this->hasPreferredDomesticCarrierCode() == $other->hasPreferredDomesticCarrierCode() &&
-            (!$this->hasPreferredDomesticCarrierCode() || $this->getPreferredDomesticCarrierCode(
-            ) == $other->getPreferredDomesticCarrierCode());
-        return $sameCountry && $sameNational && $sameExt && $sameLead && $sameZeros && $sameRaw && $sameCountrySource && $samePrefCar;
+        return $this->countryCode === $other->countryCode
+            && $this->nationalNumber === $other->nationalNumber
+            && $this->extension === $other->extension
+            && $this->italianLeadingZero === $other->italianLeadingZero
+            && $this->numberOfLeadingZeros === $other->numberOfLeadingZeros
+            && $this->rawInput === $other->rawInput
+            && $this->countryCodeSource = $other->countryCodeSource
+            && $this->preferredDomesticCarrierCode === $other->preferredDomesticCarrierCode;
     }
 
     /**


### PR DESCRIPTION
This PR addresses #567.

The `equals` method of the `PhoneNumber` class does different checks on each property which can be simplified with a simple `===` comparison. Additionally we can work on the properties directly without using haser and getter methods. Both of these changes improve performance a lot.

A short circuit for comparison of the identical instance was added.

The comparison of the class name was removed, too, because the type check of the parameters already makes sure that an instance of PhoneNumber is passed.

If somebody extends the class he can override and  extend the equals method, too. So a class name check is not required.