### PR TITLE
Remove Turkey from tests due to name change

### DIFF
--- a/tests/Issues/LocaleTest.php
+++ b/tests/Issues/LocaleTest.php
@@ -288,7 +288,6 @@ class LocaleTest extends TestCase
             'TO' => 'Tonga',
             'TT' => 'Trinidad & Tobago',
             'TN' => 'Tunisia',
-            'TR' => 'Turkey',
             'TM' => 'Turkmenistan',
             'TC' => 'Turks & Caicos Islands',
             'TV' => 'Tuvalu',


### PR DESCRIPTION
Avoid CLDR differences in the tests.