### PR TITLE
use absolute path to find data

### DIFF
--- a/src/PhoneNumberToCarrierMapper.php
+++ b/src/PhoneNumberToCarrierMapper.php
@@ -19,7 +19,7 @@ class PhoneNumberToCarrierMapper
      */
     protected static $instance = array();
 
-    const MAPPING_DATA_DIRECTORY = '/carrier/data/';
+    const MAPPING_DATA_DIRECTORY = __DIR__ . DIRECTORY_SEPARATOR . '/carrier/data/';
 
     /**
      * @var PhoneNumberUtil
@@ -32,7 +32,7 @@ class PhoneNumberToCarrierMapper
 
     protected function __construct($phonePrefixDataDirectory)
     {
-        $this->prefixFileReader = new PrefixFileReader(__DIR__ . DIRECTORY_SEPARATOR . $phonePrefixDataDirectory);
+        $this->prefixFileReader = new PrefixFileReader($phonePrefixDataDirectory);
         $this->phoneUtil = PhoneNumberUtil::getInstance();
     }
 

--- a/src/PhoneNumberToCarrierMapper.php
+++ b/src/PhoneNumberToCarrierMapper.php
@@ -12,6 +12,8 @@ namespace libphonenumber;
 use Giggsey\Locale\Locale;
 use libphonenumber\prefixmapper\PrefixFileReader;
 
+define('mapping_data_directory', __DIR__ . DIRECTORY_SEPARATOR . '/carrier/data/');
+
 class PhoneNumberToCarrierMapper
 {
     /**
@@ -19,7 +21,7 @@ class PhoneNumberToCarrierMapper
      */
     protected static $instance = array();
 
-    const MAPPING_DATA_DIRECTORY = __DIR__ . DIRECTORY_SEPARATOR . '/carrier/data/';
+    const MAPPING_DATA_DIRECTORY = mapping_data_directory;
 
     /**
      * @var PhoneNumberUtil

--- a/src/PhoneNumberUtil.php
+++ b/src/PhoneNumberUtil.php
@@ -36,8 +36,8 @@ class PhoneNumberUtil
     const MAX_LENGTH_COUNTRY_CODE = 3;
 
     const REGION_CODE_FOR_NON_GEO_ENTITY = '001';
-    const META_DATA_FILE_PREFIX = 'PhoneNumberMetadata';
-    const TEST_META_DATA_FILE_PREFIX = 'PhoneNumberMetadataForTesting';
+    const META_DATA_FILE_PREFIX = __DIR__ . '/data/' .'PhoneNumberMetadata';
+    //const TEST_META_DATA_FILE_PREFIX = 'PhoneNumberMetadataForTesting';
 
     // Region-code for the unknown region.
     const UNKNOWN_REGION = 'ZZ';
@@ -437,7 +437,7 @@ class PhoneNumberUtil
             }
 
             if ($metadataSource === null) {
-                $metadataSource = new MultiFileMetadataSourceImpl($metadataLoader, __DIR__ . '/data/' . $baseFileLocation);
+                $metadataSource = new MultiFileMetadataSourceImpl($metadataLoader, $baseFileLocation);
             }
 
             static::$instance = new static($metadataSource, $countryCallingCodeToRegionCodeMap);

--- a/src/PhoneNumberUtil.php
+++ b/src/PhoneNumberUtil.php
@@ -19,6 +19,9 @@ use libphonenumber\Leniency\AbstractLeniency;
  * @author Shaopeng Jia
  * @see https://github.com/google/libphonenumber
  */
+
+define('meta_data_file_prefix', __DIR__ . '/data/' .'PhoneNumberMetadata');
+
 class PhoneNumberUtil
 {
     /** Flags to use when compiling regular expressions for phone numbers */
@@ -36,7 +39,7 @@ class PhoneNumberUtil
     const MAX_LENGTH_COUNTRY_CODE = 3;
 
     const REGION_CODE_FOR_NON_GEO_ENTITY = '001';
-    const META_DATA_FILE_PREFIX = __DIR__ . '/data/' .'PhoneNumberMetadata';
+    const META_DATA_FILE_PREFIX = meta_data_file_prefix;
     //const TEST_META_DATA_FILE_PREFIX = 'PhoneNumberMetadataForTesting';
 
     // Region-code for the unknown region.

--- a/src/geocoding/PhoneNumberOfflineGeocoder.php
+++ b/src/geocoding/PhoneNumberOfflineGeocoder.php
@@ -9,9 +9,11 @@ use libphonenumber\PhoneNumberType;
 use libphonenumber\PhoneNumberUtil;
 use libphonenumber\prefixmapper\PrefixFileReader;
 
+define('mapping_data_directory', __DIR__ . DIRECTORY_SEPARATOR . '/data');
+
 class PhoneNumberOfflineGeocoder
 {
-    const MAPPING_DATA_DIRECTORY = __DIR__ . DIRECTORY_SEPARATOR . '/data';
+    const MAPPING_DATA_DIRECTORY = mapping_data_directory;
     /**
      * @var PhoneNumberOfflineGeocoder
      */

--- a/src/geocoding/PhoneNumberOfflineGeocoder.php
+++ b/src/geocoding/PhoneNumberOfflineGeocoder.php
@@ -11,7 +11,7 @@ use libphonenumber\prefixmapper\PrefixFileReader;
 
 class PhoneNumberOfflineGeocoder
 {
-    const MAPPING_DATA_DIRECTORY = '/data';
+    const MAPPING_DATA_DIRECTORY = __DIR__ . DIRECTORY_SEPARATOR . '/data';
     /**
      * @var PhoneNumberOfflineGeocoder
      */
@@ -33,7 +33,7 @@ class PhoneNumberOfflineGeocoder
     {
         $this->phoneUtil = PhoneNumberUtil::getInstance();
 
-        $this->prefixFileReader = new PrefixFileReader(__DIR__ . DIRECTORY_SEPARATOR . $phonePrefixDataDirectory);
+        $this->prefixFileReader = new PrefixFileReader($phonePrefixDataDirectory);
     }
 
     /**

--- a/tests/Issues/UKNumbersTest.php
+++ b/tests/Issues/UKNumbersTest.php
@@ -10,7 +10,6 @@ use PHPUnit\Framework\TestCase;
 
 class UKNumbersTest extends TestCase
 {
-    const META_DATA_FILE_PREFIX = 'PhoneNumberMetadata';
     /**
      * @var \libphonenumber\PhoneNumberUtil
      */
@@ -20,7 +19,7 @@ class UKNumbersTest extends TestCase
     {
         PhoneNumberUtil::resetInstance();
         $this->phoneUtil = PhoneNumberUtil::getInstance(
-            self::META_DATA_FILE_PREFIX,
+            PhoneNumberUtil::META_DATA_FILE_PREFIX,
             CountryCodeToRegionCodeMap::$countryCodeToRegionCodeMap
         );
     }

--- a/tests/carrier/PhoneNumberToCarrierMapperTest.php
+++ b/tests/carrier/PhoneNumberToCarrierMapperTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class PhoneNumberToCarrierMapperTest extends TestCase
 {
-    const TEST_META_DATA_FILE_PREFIX = '/../tests/carrier/data/';
+    const TEST_MAPPING_DATA_DIRECTORY = __DIR__ . DIRECTORY_SEPARATOR . 'data/';
     private static $AO_MOBILE1;
     private static $AO_MOBILE2;
     private static $AO_FIXED1;
@@ -78,7 +78,7 @@ class PhoneNumberToCarrierMapperTest extends TestCase
 
     public function setUp()
     {
-        $this->carrierMapper = PhoneNumberToCarrierMapper::getInstance(self::TEST_META_DATA_FILE_PREFIX);
+        $this->carrierMapper = PhoneNumberToCarrierMapper::getInstance(self::TEST_MAPPING_DATA_DIRECTORY);
     }
 
     public function testGetNameForMobilePortableRegion()

--- a/tests/carrier/PhoneNumberToCarrierMapperTest.php
+++ b/tests/carrier/PhoneNumberToCarrierMapperTest.php
@@ -7,9 +7,11 @@ use libphonenumber\PhoneNumberToCarrierMapper;
 use libphonenumber\PhoneNumberUtil;
 use PHPUnit\Framework\TestCase;
 
+define('test_mapping_data_directory', __DIR__ . DIRECTORY_SEPARATOR . 'data/');
+
 class PhoneNumberToCarrierMapperTest extends TestCase
 {
-    const TEST_MAPPING_DATA_DIRECTORY = __DIR__ . DIRECTORY_SEPARATOR . 'data/';
+    const TEST_MAPPING_DATA_DIRECTORY = test_mapping_data_directory;
     private static $AO_MOBILE1;
     private static $AO_MOBILE2;
     private static $AO_FIXED1;

--- a/tests/core/PhoneNumberUtilTest.php
+++ b/tests/core/PhoneNumberUtilTest.php
@@ -17,9 +17,11 @@ use libphonenumber\RegionCode;
 use libphonenumber\ValidationResult;
 use PHPUnit\Framework\TestCase;
 
+define('test_meta_data_file_prefix', __DIR__ . DIRECTORY_SEPARATOR . 'data/PhoneNumberMetadataForTesting');
+
 class PhoneNumberUtilTest extends TestCase
 {
-    const TEST_META_DATA_FILE_PREFIX = __DIR__ . DIRECTORY_SEPARATOR . 'data/PhoneNumberMetadataForTesting';
+    const TEST_META_DATA_FILE_PREFIX = test_meta_data_file_prefix;
     private static $bsNumber;
     private static $coFixedLine;
     private static $internationalTollFree;

--- a/tests/core/PhoneNumberUtilTest.php
+++ b/tests/core/PhoneNumberUtilTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 
 class PhoneNumberUtilTest extends TestCase
 {
-    const TEST_META_DATA_FILE_PREFIX = '../../tests/core/data/PhoneNumberMetadataForTesting';
+    const TEST_META_DATA_FILE_PREFIX = __DIR__ . DIRECTORY_SEPARATOR . 'data/PhoneNumberMetadataForTesting';
     private static $bsNumber;
     private static $coFixedLine;
     private static $internationalTollFree;

--- a/tests/geocoding/PhoneNumberOfflineGeocoderTest.php
+++ b/tests/geocoding/PhoneNumberOfflineGeocoderTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class PhoneNumberOfflineGeocoderTest extends TestCase
 {
-    const TEST_META_DATA_FILE_PREFIX = '/../../tests/prefixmapper/data';
+    const TEST_META_DATA_FILE_PREFIX = __DIR__ . DIRECTORY_SEPARATOR . '../prefixmapper/data';
     private static $KO_Number1;
     private static $KO_Number2;
     private static $KO_Number3;

--- a/tests/geocoding/PhoneNumberOfflineGeocoderTest.php
+++ b/tests/geocoding/PhoneNumberOfflineGeocoderTest.php
@@ -6,9 +6,11 @@ use libphonenumber\geocoding\PhoneNumberOfflineGeocoder;
 use libphonenumber\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
+define('test_meta_data_file_prefix', __DIR__ . DIRECTORY_SEPARATOR . '../prefixmapper/data');
+
 class PhoneNumberOfflineGeocoderTest extends TestCase
 {
-    const TEST_META_DATA_FILE_PREFIX = __DIR__ . DIRECTORY_SEPARATOR . '../prefixmapper/data';
+    const TEST_META_DATA_FILE_PREFIX = test_meta_data_file_prefix;
     private static $KO_Number1;
     private static $KO_Number2;
     private static $KO_Number3;


### PR DESCRIPTION
When the tests folder is not next to the src folder, about 200 tests will fail. To workaround this, use absolute path instead of relative paths to set the data dir.

Hopefully I didn't miss some files, but the tests with this change.