### PR TITLE
Configure libphonenumber-for-php-lite to be replaced by this package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,9 @@
     "symfony/console": "^2.8|^3.0|^v4.4|^v5.2",
     "php-coveralls/php-coveralls": "^1.0|^2.0"
   },
+  "replace": {
+    "giggsey/libphonenumber-for-php-lite": "self.version"
+  },
   "extra": {
     "branch-alias": {
       "dev-master": "8.x-dev"


### PR DESCRIPTION
`libphonenumber-for-php-lite` is currently configured to conflict with `libphonenumber-for-php`. This leads to both packages not being able to be installed simultaneously, which is of course intended behavior.

However, this breaks the dependency chain for packages requiring either of them.

Imagine the following scenario:

- project dependencies
    - libphonenumber-for-php
    - some-package


- some-package dependencies
    - libphonenumber-for-php-lite

This will **fail** because of the conflict configuration.

It'd be better to:
1. Configure `libphonenumber-for-php` to replace `libphonenumber-for-php-lite`
2. Remove the conflict configuration from `libphonenumber-for-php-lite`

`replace` means: this package provides everything the other package has as well in the very same namespace (and probably more).

This way, `libphonenumber-for-php-lite` gets installed when it's the only package requested from the family. But whenever any dependency (either project or package) requires `libphonenumber-for-php`, only that gets installed without conflict failures 'cause everything `lite` has to offer is defined to be also available in the original.