### PR TITLE
Update Phone mask for mobile number Uganda

### DIFF
--- a/src/data/PhoneNumberMetadata_UG.php
+++ b/src/data/PhoneNumberMetadata_UG.php
@@ -42,7 +42,7 @@ return array (
   ),
   'mobile' => 
   array (
-    'NationalNumberPattern' => '72(?:[48]0|6[01])\d{5}|7(?:[015-8]\d|20|36|4[0-4]|9[89])\d{6}|74\d{7}',
+    'NationalNumberPattern' => '72(?:[48]0|6[01])\\d{5}|7(?:[015-8]\\d|20|36|4[0-4]|9[89])\\d{6}|74\d{7}',
     'ExampleNumber' => '712345678',
     'PossibleLength' => 
     array (

--- a/src/data/PhoneNumberMetadata_UG.php
+++ b/src/data/PhoneNumberMetadata_UG.php
@@ -42,7 +42,7 @@ return array (
   ),
   'mobile' => 
   array (
-    'NationalNumberPattern' => '72(?:[48]0|6[01])\\d{5}|7(?:[015-8]\\d|20|36|4[0-4]|9[89])\\d{6}|74\d{7}',
+    'NationalNumberPattern' => '72(?:[48]0|6[01])\\d{5}|7(?:[015-8]\\d|20|36|4[0-5]|9[89])\\d{6}|74\d{7}',
     'ExampleNumber' => '712345678',
     'PossibleLength' => 
     array (

--- a/src/data/PhoneNumberMetadata_UG.php
+++ b/src/data/PhoneNumberMetadata_UG.php
@@ -42,7 +42,7 @@ return array (
   ),
   'mobile' => 
   array (
-    'NationalNumberPattern' => '72(?:[48]0|6[01])\\d{5}|7(?:[015-8]\\d|20|36|4[0-5]|9[89])\\d{6}',
+    'NationalNumberPattern' => '72(?:[48]0|6[01])\d{5}|7(?:[015-8]\d|20|36|4[0-4]|9[89])\d{6}|74\d{7}',
     'ExampleNumber' => '712345678',
     'PossibleLength' => 
     array (


### PR DESCRIPTION
This pull request introduces changes to our phone number validation logic. The current validation rules do not support phone numbers in the 74 XXXXXXXXX format, causing valid numbers to be incorrectly flagged as invalid.

The changes in this pull request ensure that phone numbers starting with ‘74’ and followed by seven additional digits are correctly validated. This update is crucial for our users who have been unable to register their valid phone numbers due to this oversight.

Please review the changes and let me know if there are any concerns or suggestions for improvement.