### PR TITLE
Revert BC break in visibility change to `PhoneNumberUtil::UNKNOWN_REGION`

### DIFF
--- a/src/PhoneNumberUtil.php
+++ b/src/PhoneNumberUtil.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace libphonenumber;
 
-use libphonenumber\Leniency\AbstractLeniency;
 use InvalidArgumentException;
+use libphonenumber\Leniency\AbstractLeniency;
 use RuntimeException;
 use TypeError;
 
@@ -55,7 +55,7 @@ class PhoneNumberUtil
     public const REGION_CODE_FOR_NON_GEO_ENTITY = '001';
 
     // Region-code for the unknown region.
-    protected const UNKNOWN_REGION = 'ZZ';
+    public const UNKNOWN_REGION = 'ZZ';
 
     protected const NANPA_COUNTRY_CODE = 1;
     /**


### PR DESCRIPTION
https://github.com/giggsey/libphonenumber-for-php/commit/b6da845e8fa72c317c2e213b9bebcdd5fbe8428c introduced a number of BC breaking changes in visibility to constants and static members. This patch only addresses one of them.

It is useful to have public access to the value this library uses to signify an unknown region.

Closes #690 
