### PR TITLE
Add a BC layer in PhoneNumber serialize method

### DIFF
--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -392,9 +392,15 @@ class PhoneNumber implements Serializable
             $this->italianLeadingZero,
             $this->numberOfLeadingZeros,
             $this->rawInput,
-            $this->countryCodeSource,
+            $countryCodeSource,
             $this->preferredDomesticCarrierCode
         ] = $data;
+
+        // BC layer to allow this method to unserialize "old" phonenumbers
+        if (is_int($countryCodeSource)) {
+            $countryCodeSource = CountryCodeSource::from($countryCodeSource);
+        }
+        $this->countryCodeSource = $countryCodeSource;
 
         if ($this->numberOfLeadingZeros > 1) {
             $this->hasNumberOfLeadingZeros = true;

--- a/tests/core/PhoneNumberTest.php
+++ b/tests/core/PhoneNumberTest.php
@@ -132,4 +132,11 @@ class PhoneNumberTest extends TestCase
 
         self::assertEquals($numberA, unserialize(serialize($numberB)));
     }
+
+    public function testUnserializeWithOldPhoneNumberData(): void
+    {
+        $oldPhoneNumberSerialized = 'O:26:"libphonenumber\PhoneNumber":8:{i:0;N;i:1;N;i:2;N;i:3;N;i:4;i:1;i:5;N;i:6;i:4;i:7;N;}';
+
+        self::assertEquals(new PhoneNumber(), unserialize($oldPhoneNumberSerialized));
+    }
 }


### PR DESCRIPTION
While trying to upgrade the PhoneNumberBundle (see https://github.com/odolbeau/phone-number-bundle/pull/193) my application wasn't able to deserialize an "old" serialized phone number.

I added a BC layer in `PhoneNumber` to allow deserialisation of an "old" `CountryCodeSource` (from int to enum).