### PR TITLE
Remove `@internal` annotation from `NumberFormat` to allow using it for `PhoneNumberUtil::formatByPattern()`

### DIFF
--- a/src/NumberFormat.php
+++ b/src/NumberFormat.php
@@ -6,7 +6,6 @@ namespace libphonenumber;
 
 /**
  * Number Format
- * @internal
  */
 class NumberFormat
 {


### PR DESCRIPTION
Resolves https://github.com/giggsey/libphonenumber-for-php/issues/718